### PR TITLE
feat(cmd): add `login-as` command for user pool authentication

### DIFF
--- a/cmd/loginAs.go
+++ b/cmd/loginAs.go
@@ -1,0 +1,79 @@
+/*
+Copyright © 2025 Ken'ichiro Oyama <k1lowxb@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/k1LoW/coglet/userpool"
+	"github.com/spf13/cobra"
+)
+
+var (
+	client       string
+	clientSecret string
+)
+
+var loginAsCmd = &cobra.Command{
+	Use:   "login-as [USER_POOL_ID_OR_NAME] [USERNAME]",
+	Short: "login as the user in the user pool",
+	Long:  `login as the user in the user pool.`,
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		idOrName := args[0]
+		username := args[1]
+		up, err := userpool.New(idOrName)
+		if err != nil {
+			return err
+		}
+		if password == "" {
+			password = os.Getenv("COGLET_PASSWORD")
+		}
+		if clientSecret == "" {
+			clientSecret = os.Getenv("COGLET_CLIENT_SECRET")
+		}
+		user := userpool.User{
+			Username: username,
+			Password: password,
+		}
+		out, err := up.LoginAs(ctx, user, userpool.WithClientSecret(clientSecret), userpool.WithClientIDOrName(client))
+		if err != nil {
+			return err
+		}
+		b, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(loginAsCmd)
+	loginAsCmd.Flags().StringVarP(&password, "password", "p", "", "password. if not set, use COGLET_PASSWORD env")
+	loginAsCmd.Flags().StringVarP(&client, "client", "c", "", "client id or name")
+	loginAsCmd.Flags().StringVarP(&clientSecret, "client-secret", "s", "", "client secret. if not set, use COGLET_CLIENT_SECRET env")
+}


### PR DESCRIPTION
This pull request introduces a new command `login-as` to the `cmd` package and adds support for user login functionality in the `userpool` package. The most important changes include the addition of the `login-as` command, new options for handling client ID and client secret, and the implementation of the `LoginAs` method in the `userpool` package.

### New Command Implementation:
* [`cmd/loginAs.go`](diffhunk://#diff-8d65b7b5751088fd5850ee7c45e6899422526b20aff717eea1695384484af808R1-R79): Added the `login-as` command to allow users to log in as a specific user in the user pool. This includes handling command-line arguments, environment variables, and printing the output in JSON format.

### Userpool Package Enhancements:
* [`userpool/userpool.go`](diffhunk://#diff-6f7de58235f6aa22d833ce05cb46048d3ae91ed280b95048fbd8697a639b4a80R38-R44): Introduced `LoginAsOption` and `LoginAsOptionFunc` types to handle client ID and client secret options for the `LoginAs` method.
* [`userpool/userpool.go`](diffhunk://#diff-6f7de58235f6aa22d833ce05cb46048d3ae91ed280b95048fbd8697a639b4a80R79-R92): Added `WithClientIDOrName` and `WithClientSecret` functions to create `LoginAsOptionFunc` for setting client ID and client secret.
* [`userpool/userpool.go`](diffhunk://#diff-6f7de58235f6aa22d833ce05cb46048d3ae91ed280b95048fbd8697a639b4a80R172-R238): Implemented the `LoginAs` method to authenticate a user using the provided client ID, client secret, and user credentials. This method handles listing user pool clients and generating the secret hash if a client secret is provided.
* [`userpool/userpool.go`](diffhunk://#diff-6f7de58235f6aa22d833ce05cb46048d3ae91ed280b95048fbd8697a639b4a80R369-R374): Added a helper function `secretHash` to generate the secret hash using HMAC-SHA256 for client authentication.