### PR TITLE
feat(cmd): add support for CSV input in `apply-users` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ coglet apply-users [USER_POOL_ID_OR_NAME] [USERS_FILE]
 
 - `USERS_FILE`: Path to a file containing user data. Each line in the file should contain a JSON object representing a user (known as [JSONL](https://jsonlines.org/)). Empty lines and lines starting with `#` are ignored.
 
+### Users file format
+
+#### JSONL
+
 The user JSON format by line should be:
 
 ```json
@@ -38,6 +42,18 @@ expanded is:
     "custom:attribute": "value"
   }
 }
+```
+
+#### CSV
+
+Read as CSV file by defining CSV format with `--columns` flag.
+
+```
+--columns username,password,email,email_verified,,phone_number,custom:attribute
+```
+
+```csv
+user1,optional-password,user1@example.com,true,,+1234567890,value
 ```
 
 #### Flags


### PR DESCRIPTION
This pull request introduces support for importing users from a CSV file in addition to the existing JSONL format. The changes include updates to the documentation and modifications to the command-line tool to handle the new CSV format.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R24): Added a new section describing the CSV format for the users file and how to specify the columns using the `--columns` flag. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R47-R58)

### Code updates:

* [`cmd/applyUsers.go`](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683R47): Introduced a new variable `cols` to store the column definitions for the CSV format.
* [`cmd/applyUsers.go`](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683R116-R140): Updated the `applyUsersCmd` command to parse users from a CSV file if the `--columns` flag is provided.
* [`cmd/applyUsers.go`](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683R180): Added a new flag `--columns` to define the columns for the CSV format.