### PR TITLE
feat(userpool): add support for client metadata in user creation, update and login

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ coglet apply-users [USER_POOL_ID_OR_NAME] [USERS_FILE]
 
 - `--dry-run`: Perform a dry run without actually creating or updating users. Useful for testing.
 
+- `--client-metadata <string>`: Set client metadata for all users. This can be provided in JSON format (`{"key1":"value1","key2":"value2"}`) or as key-value pairs (`key1=value1,key2=value2`). This metadata is passed to the Cognito service during user creation/update and can be used for custom workflows.
+
 - `--columns <string>`: Define the column structure for CSV format. Specify a comma-separated list of column names that map to user attributes. Use `username` and `password` for those fields, and attribute names for other columns. Empty values (,,) are skipped. Example: `--columns username,password,email,email_verified,,phone_number,custom:attribute`
 
 #### Users file format
@@ -104,6 +106,12 @@ Test the command without making changes:
 
 ```
 coglet apply-users MyUserPool users.jsonl --dry-run
+```
+
+Apply users with additional client metadata:
+
+```
+coglet apply-users MyUserPool users.jsonl --client-metadata '{"source":"batch-import","department":"HR"}'
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ coglet apply-users [USER_POOL_ID_OR_NAME] [USERS_FILE]
 The user JSON format by line should be:
 
 ```json
-{"username": "user1", "password": "optional-password", "attributes": {"email": "user1@example.com", "email_verified": true, "phone_number": "+1234567890", "custom:attribute": "value"}}
+{"username": "user1", "password": "optional-password", "attributes": {"email": "user1@example.com", "email_verified": true, "phone_number": "+1234567890", "custom:attribute": "value"}, "clientMetadata": {"KeyName1":"string"}}
 ```
 
 expanded is:
@@ -54,6 +54,9 @@ expanded is:
     "email_verified": true,
     "phone_number": "+1234567890",
     "custom:attribute": "value"
+  },
+  "clientMetadata": {
+    "KeyName1":"string"
   }
 }
 ```

--- a/cmd/applyUsers.go
+++ b/cmd/applyUsers.go
@@ -213,6 +213,9 @@ func init() {
 func parseClientMetadata(in string) (map[string]string, error) {
 	// {"key1":"value1","key2":"value2"}
 	m := map[string]string{}
+	if in == "" {
+		return m, nil
+	}
 	if err := json.Unmarshal([]byte(in), &m); err == nil {
 		return m, nil
 	}
@@ -220,7 +223,7 @@ func parseClientMetadata(in string) (map[string]string, error) {
 	for _, kv := range strings.Split(in, ",") {
 		kv := strings.Split(kv, "=")
 		if len(kv) != 2 {
-			return nil, fmt.Errorf("invalid format")
+			return nil, fmt.Errorf("invalid format for client metadata")
 		}
 		m[kv[0]] = kv[1]
 	}

--- a/cmd/applyUsers.go
+++ b/cmd/applyUsers.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"regexp"
 	"strings"
@@ -46,6 +47,7 @@ var (
 	dryRun                bool
 	verbose               bool
 	cols                  string
+	clientMetadata        string
 )
 
 var applyUsersCmd = &cobra.Command{
@@ -96,6 +98,11 @@ var applyUsersCmd = &cobra.Command{
 			slog.Info("apply users started")
 		}
 
+		cm, err := parseClientMetadata(clientMetadata)
+		if err != nil {
+			return err
+		}
+
 		ctx, cancel := donegroup.WithCancel(ctx)
 
 		applied := atomic.Int64{}
@@ -114,7 +121,10 @@ var applyUsersCmd = &cobra.Command{
 			if line == "" || strings.HasPrefix(line, "#") {
 				continue
 			}
-			var user userpool.User
+			user := userpool.User{
+				Attributes:     map[string]any{},
+				ClientMetadata: map[string]string{},
+			}
 			if cols == "" {
 				// AS JSONL
 				if err := json.Unmarshal([]byte(line), &user); err != nil {
@@ -122,7 +132,6 @@ var applyUsersCmd = &cobra.Command{
 				}
 			} else {
 				// CSV
-				user.Attributes = map[string]any{}
 				keys := strings.Split(cols, ",")
 				fields := strings.Split(line, ",")
 				if len(keys) != len(fields) {
@@ -141,6 +150,10 @@ var applyUsersCmd = &cobra.Command{
 					}
 				}
 			}
+
+			// additinal client metadata
+			maps.Copy(user.ClientMetadata, cm)
+
 			if filterRe != nil && !filterRe.MatchString(user.Username) {
 				if verbose {
 					slog.Info("skip user", slog.String("username", user.Username))
@@ -192,6 +205,24 @@ func init() {
 	applyUsersCmd.Flags().BoolVarP(&sendPasswordResetCode, "send-password-reset-code", "s", false, "send password reset code")
 	applyUsersCmd.Flags().StringVarP(&filter, "filter", "f", "", "filter apply users")
 	applyUsersCmd.Flags().StringVarP(&cols, "columns", "c", "", "define columns for CSV format")
+	applyUsersCmd.Flags().StringVarP(&clientMetadata, "client-metadata", "m", "", "set client metadata")
 	applyUsersCmd.Flags().BoolVar(&dryRun, "dry-run", false, "dry run")
 	applyUsersCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+}
+
+func parseClientMetadata(in string) (map[string]string, error) {
+	// {"key1":"value1","key2":"value2"}
+	m := map[string]string{}
+	if err := json.Unmarshal([]byte(in), &m); err == nil {
+		return m, nil
+	}
+	// key1=value1,key2=value2
+	for _, kv := range strings.Split(in, ",") {
+		kv := strings.Split(kv, "=")
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid format")
+		}
+		m[kv[0]] = kv[1]
+	}
+	return m, nil
 }

--- a/cmd/loginAs.go
+++ b/cmd/loginAs.go
@@ -48,9 +48,14 @@ var loginAsCmd = &cobra.Command{
 		if password == "" {
 			password = os.Getenv("COGLET_PASSWORD")
 		}
+		cm, err := parseClientMetadata(clientMetadata)
+		if err != nil {
+			return nil
+		}
 		user := userpool.User{
-			Username: username,
-			Password: password,
+			Username:       username,
+			Password:       password,
+			ClientMetadata: cm,
 		}
 		out, err := up.LoginAs(ctx, user, userpool.WithClientIDOrName(client))
 		if err != nil {
@@ -69,4 +74,5 @@ func init() {
 	rootCmd.AddCommand(loginAsCmd)
 	loginAsCmd.Flags().StringVarP(&password, "password", "p", "", "password. if not set, use COGLET_PASSWORD env")
 	loginAsCmd.Flags().StringVarP(&client, "client", "c", "", "user pool client id or name")
+	loginAsCmd.Flags().StringVarP(&clientMetadata, "client-metadata", "m", "", "set client metadata")
 }

--- a/userpool/userpool.go
+++ b/userpool/userpool.go
@@ -21,9 +21,10 @@ type Client struct {
 }
 
 type User struct {
-	Username   string         `json:"username"`
-	Password   string         `json:"password,omitempty"`
-	Attributes map[string]any `json:"attributes,omitempty"`
+	Username       string            `json:"username"`
+	Password       string            `json:"password,omitempty"`
+	Attributes     map[string]any    `json:"attributes,omitempty"`
+	ClientMetadata map[string]string `json:"clientMetadata,omitempty"`
 }
 
 type ApplyUserOption struct {
@@ -227,6 +228,7 @@ func (c *Client) LoginAs(ctx context.Context, user User, opts ...LoginAsOptionFu
 			"PASSWORD":    user.Password,
 			"SECRET_HASH": secretHash(*clientID, *uc.UserPoolClient.ClientSecret, user.Username),
 		},
+		ClientMetadata: user.ClientMetadata,
 	}
 
 	// use initiated-login
@@ -235,8 +237,9 @@ func (c *Client) LoginAs(ctx context.Context, user User, opts ...LoginAsOptionFu
 
 func (c *Client) createUser(ctx context.Context, user User) error {
 	input := &cognito.AdminCreateUserInput{
-		UserPoolId: aws.String(c.userPoolID),
-		Username:   aws.String(user.Username),
+		UserPoolId:     aws.String(c.userPoolID),
+		Username:       aws.String(user.Username),
+		ClientMetadata: user.ClientMetadata,
 	}
 	if _, err := c.client.AdminCreateUser(ctx, input); err != nil {
 		return err
@@ -257,6 +260,7 @@ func (c *Client) updateUserAttributes(ctx context.Context, user User) error {
 		UserPoolId:     aws.String(c.userPoolID),
 		Username:       aws.String(user.Username),
 		UserAttributes: userAttrs,
+		ClientMetadata: user.ClientMetadata,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request introduces the ability to set client metadata for users in the `coglet` tool. The changes include updates to the command-line interface, documentation, and internal handling of user data to support this new feature.

### Documentation updates:
* Added `--client-metadata` option to `coglet apply-users` command, allowing users to specify client metadata in JSON format or as key-value pairs.
* Updated JSON user format examples to include `clientMetadata` field. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R59-R61)
* Added example usage of `--client-metadata` in the documentation.

### Code updates:
* Imported `maps` package in `cmd/applyUsers.go` to facilitate copying metadata.
* Added `clientMetadata` flag and parsing logic in `cmd/applyUsers.go` and `cmd/loginAs.go`. [[1]](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683R50) [[2]](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683R208-R231) [[3]](diffhunk://#diff-8d65b7b5751088fd5850ee7c45e6899422526b20aff717eea1695384484af808R77)
* Updated user creation and update logic to include `ClientMetadata` in `userpool/userpool.go`. [[1]](diffhunk://#diff-6f7de58235f6aa22d833ce05cb46048d3ae91ed280b95048fbd8697a639b4a80R242) [[2]](diffhunk://#diff-6f7de58235f6aa22d833ce05cb46048d3ae91ed280b95048fbd8697a639b4a80R263)

### Internal handling:
* Modified `User` struct in `userpool/userpool.go` to include `ClientMetadata` field.
* Integrated metadata parsing and assignment in `applyUsersCmd` and `loginAsCmd` command implementations. [[1]](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683R101-R105) [[2]](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683L117-L125) [[3]](diffhunk://#diff-8d65b7b5751088fd5850ee7c45e6899422526b20aff717eea1695384484af808R51-R58) [[4]](diffhunk://#diff-6f7de58235f6aa22d833ce05cb46048d3ae91ed280b95048fbd8697a639b4a80R231)