### PR TITLE
feat: add endpoint configuration to userpool

### DIFF
--- a/cmd/applyUsers.go
+++ b/cmd/applyUsers.go
@@ -48,6 +48,7 @@ var (
 	verbose               bool
 	cols                  string
 	clientMetadata        string
+	endpoint              string
 )
 
 var applyUsersCmd = &cobra.Command{
@@ -59,7 +60,7 @@ var applyUsersCmd = &cobra.Command{
 		ctx := cmd.Context()
 		idOrName := args[0]
 		p := args[1]
-		up, err := userpool.New(idOrName)
+		up, err := userpool.New(idOrName, userpool.WithEndpoint(endpoint))
 		if err != nil {
 			return err
 		}
@@ -208,6 +209,7 @@ func init() {
 	applyUsersCmd.Flags().StringVarP(&clientMetadata, "client-metadata", "m", "", "set client metadata")
 	applyUsersCmd.Flags().BoolVar(&dryRun, "dry-run", false, "dry run")
 	applyUsersCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	applyUsersCmd.Flags().StringVarP(&endpoint, "endpoint", "e", "", "set endpoint")
 }
 
 func parseClientMetadata(in string) (map[string]string, error) {

--- a/cmd/loginAs.go
+++ b/cmd/loginAs.go
@@ -41,7 +41,7 @@ var loginAsCmd = &cobra.Command{
 		ctx := cmd.Context()
 		idOrName := args[0]
 		username := args[1]
-		up, err := userpool.New(idOrName)
+		up, err := userpool.New(idOrName, userpool.WithEndpoint(endpoint))
 		if err != nil {
 			return err
 		}
@@ -75,4 +75,5 @@ func init() {
 	loginAsCmd.Flags().StringVarP(&password, "password", "p", "", "password. if not set, use COGLET_PASSWORD env")
 	loginAsCmd.Flags().StringVarP(&client, "client", "c", "", "user pool client id or name")
 	loginAsCmd.Flags().StringVarP(&clientMetadata, "client-metadata", "m", "", "set client metadata")
+	loginAsCmd.Flags().StringVarP(&endpoint, "endpoint", "e", "", "set endpoint")
 }


### PR DESCRIPTION
This pull request introduces an enhancement to the `applyUsers` and `loginAs` commands by adding support for specifying a custom endpoint. The changes involve updating the command definitions and the user pool client initialization to accommodate this new feature.

Key changes include:

### Command Updates:
* Added a new flag `--endpoint` to the `applyUsers` and `loginAs` commands to allow users to specify a custom endpoint (`cmd/applyUsers.go`, `cmd/loginAs.go`). [[1]](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683R51) [[2]](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683R212) [[3]](diffhunk://#diff-8d65b7b5751088fd5850ee7c45e6899422526b20aff717eea1695384484af808R78)

### User Pool Client Updates:
* Modified the `userpool.New` function to accept an optional endpoint parameter using a functional options pattern. Introduced `UserPoolOption` and `UserPoolOptionFunc` types, along with a `WithEndpoint` function to set the endpoint (`userpool/userpool.go`). [[1]](diffhunk://#diff-6f7de58235f6aa22d833ce05cb46048d3ae91ed280b95048fbd8697a639b4a80R18-R30) [[2]](diffhunk://#diff-6f7de58235f6aa22d833ce05cb46048d3ae91ed280b95048fbd8697a639b4a80L86-R111)

### Command Implementation Updates:
* Updated the `applyUsers` and `loginAs` command implementations to pass the endpoint to the `userpool.New` function if the endpoint flag is set (`cmd/applyUsers.go`, `cmd/loginAs.go`). [[1]](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683L62-R63) [[2]](diffhunk://#diff-8d65b7b5751088fd5850ee7c45e6899422526b20aff717eea1695384484af808L44-R44)