### PR TITLE
fix(userpool): increase retry max attempts

### DIFF
--- a/userpool/userpool.go
+++ b/userpool/userpool.go
@@ -103,7 +103,9 @@ func New(userPoolIDOrName string, opts ...UserPoolOptionFunc) (*Client, error) {
 			return nil, err
 		}
 	}
-	copts := []func(*config.LoadOptions) error{}
+	copts := []func(*config.LoadOptions) error{
+		config.WithRetryMaxAttempts(10),
+	}
 	if opt.Endpoint != "" {
 		copts = append(copts, config.WithBaseEndpoint(opt.Endpoint))
 	}


### PR DESCRIPTION
This pull request includes a change to the `userpool/userpool.go` file to improve the configuration options for the `New` function. The change sets a default maximum retry attempt for the configuration.

Configuration improvement:

* [`userpool/userpool.go`](diffhunk://#diff-6f7de58235f6aa22d833ce05cb46048d3ae91ed280b95048fbd8697a639b4a80L106-R108): Modified the `copts` initialization in the `New` function to include `config.WithRetryMaxAttempts(10)` by default.