### PR TITLE
feat: add support for skipping header lines in CSV files

### DIFF
--- a/cmd/applyUsers.go
+++ b/cmd/applyUsers.go
@@ -47,6 +47,7 @@ var (
 	dryRun                bool
 	verbose               bool
 	cols                  string
+	skipHeader            int
 	clientMetadata        string
 	endpoint              string
 )
@@ -133,6 +134,9 @@ var applyUsersCmd = &cobra.Command{
 				}
 			} else {
 				// CSV
+				if l <= skipHeader {
+					continue
+				}
 				keys := strings.Split(cols, ",")
 				fields := strings.Split(line, ",")
 				if len(keys) != len(fields) {
@@ -206,6 +210,7 @@ func init() {
 	applyUsersCmd.Flags().BoolVarP(&sendPasswordResetCode, "send-password-reset-code", "s", false, "send password reset code")
 	applyUsersCmd.Flags().StringVarP(&filter, "filter", "f", "", "filter apply users")
 	applyUsersCmd.Flags().StringVarP(&cols, "columns", "c", "", "define columns for CSV format")
+	applyUsersCmd.Flags().IntVarP(&skipHeader, "skip-header", "S", 0, "count of CSV header lines to skip")
 	applyUsersCmd.Flags().StringVarP(&clientMetadata, "client-metadata", "m", "", "set client metadata")
 	applyUsersCmd.Flags().BoolVar(&dryRun, "dry-run", false, "dry run")
 	applyUsersCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")


### PR DESCRIPTION
This pull request to `cmd/applyUsers.go` introduces a new feature to allow skipping header lines in CSV files. The most important changes include adding a new flag for skipping headers and implementing the logic to skip the specified number of header lines.

New feature for skipping headers in CSV files:

* [`cmd/applyUsers.go`](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683R50): Added a new variable `skipHeader` to store the number of header lines to skip.
* [`cmd/applyUsers.go`](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683R137-R139): Implemented logic to skip the specified number of header lines in the CSV processing section.
* [`cmd/applyUsers.go`](diffhunk://#diff-ce95912d50c6e72d986e3e5b559153588c96ef94646e487af52c8ebf47b8a683R213): Added a new command-line flag `--skip-header` to set the number of header lines to skip.